### PR TITLE
[ALS-6058] Refactor search term selection in search view

### DIFF
--- a/ui/src/main/picsureui/overrides/router.js
+++ b/ui/src/main/picsureui/overrides/router.js
@@ -90,7 +90,8 @@ define(["backbone", "handlebars", "studyAccess/studyAccess", "picSure/settings",
                     const searchView = new SearchView({
                         queryTemplate: JSON.parse(parsedSess.queryTemplate),
                         queryScopes: parsedSess.queryScopes,
-                        el: $('#filter-list')
+                        el: $('#filter-list'),
+                        tourSearchTerm: "race",
                     });
 
                     $('#studies-list-panel').remove();


### PR DESCRIPTION
The code has been refactored to unify the selection process of search terms in search view. Regardless of open or authorized access, the search term used will now be determined by the `tourSearchTerm` option provided. Default term for open access is "epilepsy" while for authorized access it can vary, for instance, "cardiac surgery" in biodatacatalyst and "race" in aim-ahead.